### PR TITLE
updated batch file to have error handling

### DIFF
--- a/Tooling/deployment/Build.bat
+++ b/Tooling/deployment/Build.bat
@@ -19,20 +19,32 @@ cd /d C:\Program Files\NI\LVAddons
 rmdir /s /q %AddonName%
 REM Add Localhost.LibraryPaths token to LabVIEW INI
 call g-cli --lv-ver %LVVersion% --arch %SupportedBitness% -v "%RelativePath%\Tooling\deployment\NIPackage\CreateLVINILocalHostKey.vi" -- %RelativePath%
+IF %ERRORLEVEL% NEQ 0 goto end
 REM Quit LabVIEW
 call g-cli --lv-ver %LVVersion% --arch %SupportedBitness% QuitLabVIEW
+IF %ERRORLEVEL% NEQ 0 goto end
 REM Zips and moves lv_icon.lvlibp as well as LabVIEW Icon API from VI Lib to a different location
 call g-cli --lv-ver %LVVersion% --arch %SupportedBitness% -v "%RelativePath%\Tooling\PrepareIESource.vi" -- "%Project%" "Editor Packed Library"
+IF %ERRORLEVEL% NEQ 0 goto end
 REM Quit LabVIEW
 call g-cli --lv-ver %LVVersion% --arch %SupportedBitness% QuitLabVIEW
+IF %ERRORLEVEL% NEQ 0 goto end
 REM Build the PPL
 call g-cli --lv-ver %LVVersion% --arch %SupportedBitness% lvbuildspec -- -v %PackedProjectLibraryVersion% -p "%Project%" -b "%BuildSpec%"
+IF %ERRORLEVEL% NEQ 0 goto end
 REM Build VI Package
 call g-cli --lv-ver %VIPackageLabVIEWVersion% --arch %SupportedBitness% -v vipb -- -av -b "%RelativePath%\Tooling\deployment\VIPackage\NI Icon editor.vipb"
+IF %ERRORLEVEL% NEQ 0 goto end
 REM Build NI Package
 REM cd /d C:\Program Files\National Instruments\Package Builder
 REM call nipbcli -o="%NIPB_Path%" -b=packages -save
+REM IF %ERRORLEVEL% NEQ 0 goto end
 REM Removes token LocalHost.LibraryPaths from LabVIEW.ini
- call g-cli --lv-ver %LVVersion% --arch %SupportedBitness% -v "%RelativePath%\Tooling\deployment\NIPackage\DestroyLVINILocalHostKey.vi"
+call g-cli --lv-ver %LVVersion% --arch %SupportedBitness% -v "%RelativePath%\Tooling\deploymefnt\NIPackage\DestroyLVINILocalHostKey.vi"
+IF %ERRORLEVEL% NEQ 0 goto end
 REM Quit LabVIEW
 call g-cli --lv-ver %LVVersion% --arch %SupportedBitness% QuitLabVIEW
+:end 
+IF %ERRORLEVEL% NEQ 0 pause
+
+


### PR DESCRIPTION
Checks for errors between calls to LabVIEW CLI, and will pause if there is an error to show you what it failed.
 IF there is no error, the batch files exits without pausing.