### PR TITLE
Reusable Release Workflows for the Icon Editor

### DIFF
--- a/.github/workflows/build-vi-package.yml
+++ b/.github/workflows/build-vi-package.yml
@@ -26,25 +26,29 @@ jobs:
 
     steps:
       ########################################################################
-      # (A) DISABLE GPG SIGNING IF WE'RE ON A FORK
-      #     Store the old config in step outputs for restoration later
+      # (A) DISABLE GPG SIGNING IF WE'RE ON A FORK (NOT 'ni/labview-icon-editor')
       ########################################################################
       - name: Disable GPG signing (only on forks)
         if: ${{ github.repository != 'ni/labview-icon-editor' }}
         id: disable_signing
+        shell: pwsh
         run: |
-          echo "Detected fork; temporarily disabling GPG signing..."
+          Write-Host "Detected fork; temporarily disabling GPG signing..."
 
-          # Grab current config (if set)
-          currentCommitGpgsign=$(git config --global commit.gpgsign || echo "")
-          currentTagGpgsign=$(git config --global tag.gpgsign || echo "")
+          # Grab current config (if set) for commit and tag
+          $currentCommitGpgsign = git config --global commit.gpgsign
+          if (-not $currentCommitGpgsign) { $currentCommitGpgsign = "" }
 
-          echo "Found commit.gpgsign=$currentCommitGpgsign"
-          echo "Found tag.gpgsign=$currentTagGpgsign"
+          $currentTagGpgsign = git config --global tag.gpgsign
+          if (-not $currentTagGpgsign) { $currentTagGpgsign = "" }
+
+          Write-Host "Found commit.gpgsign=$currentCommitGpgsign"
+          Write-Host "Found tag.gpgsign=$currentTagGpgsign"
 
           # Make them available as step outputs
-          echo "commit_gpgsign=$currentCommitGpgsign" >> "$GITHUB_OUTPUT"
-          echo "tag_gpgsign=$currentTagGpgsign" >> "$GITHUB_OUTPUT"
+          # Use $env:GITHUB_OUTPUT to set outputs in PowerShell
+          "commit_gpgsign=$currentCommitGpgsign" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "tag_gpgsign=$currentTagGpgsign"       | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
           # Disable GPG signing for commits & tags
           git config --global commit.gpgsign false
@@ -282,19 +286,24 @@ jobs:
       ########################################################################
       - name: Re-enable GPG signing (only on forks)
         if: always() && github.repository != 'ni/labview-icon-editor'
+        shell: pwsh
         run: |
-          echo "Restoring GPG signing to previous config..."
-          oldCommitGpgsign="${{ steps.disable_signing.outputs.commit_gpgsign }}"
-          oldTagGpgsign="${{ steps.disable_signing.outputs.tag_gpgsign }}"
+          Write-Host "Restoring GPG signing to previous config..."
 
-          if [ -n "$oldCommitGpgsign" ]; then
-            git config --global commit.gpgsign "$oldCommitGpgsign"
-          else
-            git config --global --unset commit.gpgsign || true
-          fi
+          $oldCommitGpgsign = '${{ steps.disable_signing.outputs.commit_gpgsign }}'
+          $oldTagGpgsign    = '${{ steps.disable_signing.outputs.tag_gpgsign }}'
 
-          if [ -n "$oldTagGpgsign" ]; then
-            git config --global tag.gpgsign "$oldTagGpgsign"
-          else
-            git config --global --unset tag.gpgsign || true
-          fi
+          Write-Host "Previous commit.gpgsign = $oldCommitGpgsign"
+          Write-Host "Previous tag.gpgsign    = $oldTagGpgsign"
+
+          if ($oldCommitGpgsign) {
+            git config --global commit.gpgsign $oldCommitGpgsign
+          } else {
+            git config --global --unset commit.gpgsign || Write-Host "commit.gpgsign was not set."
+          }
+
+          if ($oldTagGpgsign) {
+            git config --global tag.gpgsign $oldTagGpgsign
+          } else {
+            git config --global --unset tag.gpgsign || Write-Host "tag.gpgsign was not set."
+          }


### PR DESCRIPTION
# Pull Request: Reusable Release Workflows for the Icon Editor

This pull request introduces a **fully automated, fork-friendly release workflow** for the Icon Editor project, ensuring consistent versioning and artifact generation for both the main repository and any forks.

---

## Table of Contents

1. [Overview](#overview)  
2. [Key Changes](#key-changes)  
3. [Technical Implementation](#technical-implementation)  
   - [Conditional GPG Signing](#conditional-gpg-signing)  
   - [Versioning and Tagging](#versioning-and-tagging)  
   - [Artifact Build and Release](#artifact-build-and-release)  
4. [Workflow File Highlights](#workflow-file-highlights)  
5. [How to Test](#how-to-test)  
   - [Testing on Forks](#testing-on-forks)  
   - [Testing on the Main Repo](#testing-on-the-main-repo)  
   - [Pull Requests from Forks](#pull-requests-from-forks)  
6. [Concurrency and Runner Considerations](#concurrency-and-runner-considerations)  
7. [Checklist](#checklist)  
8. [Conclusion](#conclusion)

---

## Overview

For our Icon Editor project, **automated versioning and releases** are essential to maintain consistent builds and streamline our deployment process. However, we also want to ensure that **forks** (both internal and external) can run the same release workflow without GPG signing failures or passphrase prompts.

This PR **disables GPG signing only on forked repos** (i.e., any repository other than `ni/labview-icon-editor`), while preserving GPG signing for the official repo. After the build completes on a fork, it **restores** any previous signing settings so that local development environments remain unaffected.

---

## Key Changes

1. **New Workflow**: `Build VI Package`  
   - Single workflow that handles **version bumping**, **building**, **artifact uploading**, and **GitHub release creation**.

2. **Automatic Versioning**  
   - Uses PR labels (`major`, `minor`, `patch`) to decide how much to increment the version.  
   - Defaults to a patch bump for direct pushes when there’s no PR label.  
   - Tracks a **global build number** by counting existing tags matching `v*.*.*-build*`.

3. **Tag & Release**  
   - Creates a **tag** and corresponding **GitHub release** whenever it’s not a pull request (i.e., on pushes to `main`, `develop`, `release/*`, etc.).  
   - Tags follow the format `vMAJOR.MINOR.PATCH-buildN` (or `-rc.N-buildN` for release branches).

4. **Fork-Friendly GPG Signing**  
   - If `github.repository` is not `ni/labview-icon-editor`, the workflow **temporarily disables** GPG signing (by running `git config --global commit.gpgsign false` and `git config --global tag.gpgsign false`).  
   - Stores the old settings, then **re-applies** them after the build finishes.

---

## Technical Implementation

### Conditional GPG Signing

- **Rationale**: Forks generally don’t have access to the main repo’s GPG keys, leading to signing errors.  
- **Mechanism**: We compare `github.repository` with `ni/labview-icon-editor`. If they differ, we’re on a fork.  
- **Implementation Details**:  
  1. **Disable Step**: Captures the existing `commit.gpgsign` and `tag.gpgsign` config in step outputs, then sets both to `false`.  
  2. **Restore Step**: Reads those previously saved outputs and restores them (or unsets them if empty) in a final step.

### Versioning and Tagging

- **Label-Based Bump**:  
  - Labels of `major`, `minor`, or `patch` drive the version bump.  
  - If no label (or a direct push), default is `patch`.  
- **Global Build Number**:  
  - Increments by 1 each time based on the count of existing tags matching `v*.*.*-build*`.  
  - Ensures each build produces a unique, monotonically increasing version.  
- **Tag Naming**:  
  - Default: `vX.Y.Z-buildNN`  
  - Release branches: `vX.Y.Z-rc.N-buildNN`  
  - Hotfix or `main`: produce stable tags without the `-rc` suffix.

### Artifact Build and Release

- **Build**: Invokes a PowerShell script, `Build.ps1`, that compiles the Icon Editor VI package.  
- **Artifact**: The `.vip` file is uploaded to GitHub using `actions/upload-artifact@v4`.  
- **Release Creation**:  
  - **Not** invoked for pull requests.  
  - For direct pushes or merges, automatically creates a GitHub Release for the new tag, marking it as a pre-release if it has an `-rc` suffix.

---

## Workflow File Highlights

1. **Events**:
    
        on:
          push:
            branches: [ main, develop, release/*, hotfix/* ]
          pull_request:
            branches: [ main, develop, release/*, hotfix/* ]
          workflow_dispatch:
    
2. **Disable GPG on Forks**:
    
        - name: Disable GPG signing (only on forks)
          if: ${{ github.repository != 'ni/labview-icon-editor' }}
          # ...
    
3. **Version Bump**:
    
        - name: Determine bump type
          id: bump_type
          uses: actions/github-script@v6
          # ...
    
4. **Build and Upload Artifact**:
    
        - name: Build the icon editor VI package
          # ...
        - name: Upload VIP artifact
          uses: actions/upload-artifact@v4
    
5. **Re-Enable GPG**:
    
        - name: Re-enable GPG signing (only on forks)
          if: always() && github.repository != 'ni/labview-icon-editor'
          # ...

---

## How to Test

### Testing on Forks

1. **Fork** the repository to your personal account.  
2. **Push** a commit to your fork’s `develop` or `main` branch.  
3. Observe that the workflow runs without GPG signing errors (it automatically disables signing).  
4. Confirm a tag such as `v0.0.1-build1` is created in **your fork**.

### Testing on the Main Repo

1. **Push** a commit to `develop` on `ni/labview-icon-editor`.  
2. Since `github.repository` equals the original repo name, GPG signing remains enabled.  
3. If your self-hosted runner has the keys, you’ll get a fully signed tag.  
4. Verify that a `.vip` artifact is uploaded and a GitHub Release is created (unless it’s a pull request).

### Pull Requests from Forks

1. **Create a PR** from your fork to the main repo.  
2. Assign a label (`major`, `minor`, or `patch`).  
3. The build should succeed, but it **won’t** push a tag or create a release until the PR is merged (the `Create & push tag` step is skipped for PRs).

---

## Concurrency and Runner Considerations

- **Git Config Race Condition**: Two parallel runs could both alter the global Git config if they’re on the same runner under the same user. Typically, we revert the config to minimize the risk, but a truly robust setup would isolate each job (e.g., using containers or separate user accounts).  
- **Self-Hosted Runner Labels**: Ensure that your runner is labeled `self-hosted, iconeditor` as specified in `runs-on`. Otherwise, the job might not start or might run on an unintended environment.

---

## Checklist

- [x] **YAML Validity**: Verified the workflow syntax and event triggers.  
- [x] **Permissions**: Confirmed `contents: write` in `permissions` to allow tag pushes and release creation.  
- [x] **Secrets**: Ensured that `secrets.GITHUB_TOKEN` has the correct scope for a public or private repo.  
- [x] **Artifactory**: Confirmed the `.vip` file is stored in `builds/VI Package/` so `actions/upload-artifact` can locate it.  
- [ ] **Approval**: Requires code review by Icon Editor maintainers.

---

## Conclusion

By merging this pull request, we establish a **unified, robust release pipeline** that’s safe for both internal and external contributors. Our forks now get a seamless tagging experience (without passphrase blocking), while official builds remain GPG-signed for security and integrity.

**Thank you** for your time and feedback—please share any suggestions or concerns you might have. Once approved, we’ll have a more streamlined, transparent, and contributor-friendly CI/CD process for the Icon Editor.
