### PR TITLE
Adding changes to address comments made on discord about extra noise

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
 - type: markdown
   attributes: 
     value: |
-      * IMPORTANT: Before creating an issue, start the discussion about a possible bug on our [Discord Server](https://discord.gg/q4d3ggrFVA)
+      * IMPORTANT: Specify the release number you are reporting the bug against (e.g. v0.2.0-build590). Join our [#icon-editor-dev](https://discord.gg/q4d3ggrFVA) if you have any problems or questions.
 
 - type: dropdown
   id: version

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        **IMPORTANT:** Before creating an issue, start the discussion about a possible new feature on our [Discord Server](https://discord.gg/q4d3ggrFVA).
+        **IMPORTANT:** Start the discussion on our Discord channel [#icon-editor-dev](https://discord.gg/q4d3ggrFVA) or create a [GitHub Discussion]https://github.com/ni/labview-icon-editor/discussions/new/choose **only** if you are requesting changes to the shipping version of the Icon Editor.
 
   - type: textarea
     attributes:


### PR DESCRIPTION
Adding more clarity to the github issue templates.

The way we report bugs can be optimized following comments made on Discord. 

This caused confusion because it states the same process for bugs and features, and that is not correct.