### PR TITLE
411 deterministic tag and release workflow

### DIFF
--- a/.github/actions/build-vip/action.yml
+++ b/.github/actions/build-vip/action.yml
@@ -9,6 +9,31 @@ runs:
         fetch-depth: 0
         clean: false
 
+    - name: Close LabVIEW 2021 before 2023 preflight
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $logDir = Join-Path -Path "${{ inputs.relative_path }}" -ChildPath "builds/logs"
+        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+        $logFile = Join-Path -Path $logDir -ChildPath "gcli-close-2021.log"
+
+        $gcliArgs = @(
+          "--lv-ver", "2021",
+          "--arch", "64",
+          "--connect-timeout", "30000",
+          "--kill",
+          "--kill-timeout", "5000",
+          "--verbose",
+          "QuitLabVIEW"
+        )
+
+        Write-Host "Pre-step: ensure LabVIEW 2021 closed: g-cli $($gcliArgs -join ' ')"
+        & g-cli @gcliArgs 2>&1 | Tee-Object -FilePath $logFile | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Failed to close LabVIEW 2021. Inspect $logFile for details."
+          exit $LASTEXITCODE
+        }
+
     - name: Pre-flight LabVIEW availability check
       shell: pwsh
       run: |

--- a/.github/actions/build-vip/action.yml
+++ b/.github/actions/build-vip/action.yml
@@ -9,6 +9,10 @@ runs:
         fetch-depth: 0
         clean: false
 
+    # NOTE: This step uses an inline PowerShell script instead of the standard close-labview action
+    # because it requires additional parameters (--connect-timeout, --kill, --kill-timeout, --verbose)
+    # and file logging for this critical step before 2023 packaging. The extra robustness ensures
+    # LabVIEW 2021 is fully closed before LabVIEW 2023 operations begin.
     - name: Close LabVIEW 2021 before 2023 preflight
       shell: pwsh
       run: |

--- a/.github/actions/locate-release-assets/action.yml
+++ b/.github/actions/locate-release-assets/action.yml
@@ -1,0 +1,43 @@
+name: "Locate Release Assets"
+description: "Locates VIP and release notes files for release uploads"
+inputs:
+  vip_dir:
+    description: "Directory to search for .vip files"
+    required: true
+  notes_dir:
+    description: "Directory to search for release_notes_*.md files"
+    required: true
+outputs:
+  vip_path:
+    description: "Full path to the .vip file"
+    value: ${{ steps.locate.outputs.vip_path }}
+  vip_name:
+    description: "Name of the .vip file"
+    value: ${{ steps.locate.outputs.vip_name }}
+  notes_path:
+    description: "Full path to the release notes file"
+    value: ${{ steps.locate.outputs.notes_path }}
+  notes_name:
+    description: "Name of the release notes file"
+    value: ${{ steps.locate.outputs.notes_name }}
+runs:
+  using: "composite"
+  steps:
+    - name: Locate assets
+      id: locate
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $vipDir = "${{ inputs.vip_dir }}"
+        $notesDir = "${{ inputs.notes_dir }}"
+        
+        $vip = Get-ChildItem -Path $vipDir -Filter *.vip -File -Recurse | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if (-not $vip) { Write-Error "No .vip file found in $vipDir"; exit 1 }
+
+        $notes = Get-ChildItem -Path $notesDir -Filter "release_notes_*.md" -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if (-not $notes) { Write-Error "No release_notes_*.md found in $notesDir"; exit 1 }
+
+        "vip_path=$($vip.FullName)"     | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+        "vip_name=$($vip.Name)"         | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+        "notes_path=$($notes.FullName)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+        "notes_name=$($notes.Name)"     | Out-File -FilePath $Env:GITHUB_OUTPUT -Append

--- a/.github/actions/locate-release-assets/action.yml
+++ b/.github/actions/locate-release-assets/action.yml
@@ -34,7 +34,7 @@ runs:
         $vip = Get-ChildItem -Path $vipDir -Filter *.vip -File -Recurse | Sort-Object LastWriteTime -Descending | Select-Object -First 1
         if (-not $vip) { Write-Error "No .vip file found in $vipDir"; exit 1 }
 
-        $notes = Get-ChildItem -Path $notesDir -Filter "release_notes_*.md" -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        $notes = Get-ChildItem -Path $notesDir -Filter "release_notes_*.md" -File -Recurse | Sort-Object LastWriteTime -Descending | Select-Object -First 1
         if (-not $notes) { Write-Error "No release_notes_*.md found in $notesDir"; exit 1 }
 
         "vip_path=$($vip.FullName)"     | Out-File -FilePath $Env:GITHUB_OUTPUT -Append

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -1,7 +1,7 @@
 name: CI Pipeline (Composite)
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -360,6 +360,10 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $provided = if (-not [string]::IsNullOrWhiteSpace($Env:INPUT_TAG)) { $Env:INPUT_TAG } else { $Env:REF_TAG }
+          if ([string]::IsNullOrWhiteSpace($provided)) {
+            Write-Host 'No tag provided; skipping validation.'
+            exit 0
+          }
           if ($provided -ne $Env:EXPECTED_TAG) {
             Write-Error ("Provided tag '{0}' does not match computed tag '{1}'." -f $provided, $Env:EXPECTED_TAG)
           } else {

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -25,6 +25,11 @@ on:
       - reopened
       - ready_for_review
   workflow_dispatch:
+    inputs:
+      dispatch_tag:
+        description: "Expected tag for this run (optional, for dispatched builds)"
+        required: false
+        type: string
 
 jobs:
   changes:
@@ -321,3 +326,68 @@ jobs:
         with:
           minimum_supported_lv_version: 2023
           supported_bitness: 64
+      - name: Validate tag matches computed version (if provided)
+        if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.dispatch_tag != ''
+        shell: pwsh
+        env:
+          EXPECTED_TAG: v${{ needs.version.outputs.MAJOR }}.${{ needs.version.outputs.MINOR }}.${{ needs.version.outputs.PATCH }}.${{ needs.version.outputs.BUILD }}
+          REF_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+          INPUT_TAG: ${{ github.event.inputs.dispatch_tag || '' }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $provided = if (-not [string]::IsNullOrWhiteSpace($Env:INPUT_TAG)) { $Env:INPUT_TAG } else { $Env:REF_TAG }
+          if ([string]::IsNullOrWhiteSpace($provided)) {
+            Write-Error "No provided tag (ref/input) to validate against computed tag $Env:EXPECTED_TAG."
+          }
+          if ($provided -ne $Env:EXPECTED_TAG) {
+            Write-Error ("Provided tag '{0}' does not match computed tag '{1}'." -f $provided, $Env:EXPECTED_TAG)
+          } else {
+            Write-Host ("Tag validation ok: {0}" -f $provided)
+          }
+      - name: Locate release assets
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: release-assets
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $vip = Get-ChildItem -Path "$Env:GITHUB_WORKSPACE/builds/VI Package" -Filter *.vip -File -Recurse | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $vip) { Write-Error "No .vip file found for release upload."; exit 1 }
+
+          $notes = Get-ChildItem -Path "$Env:GITHUB_WORKSPACE/Tooling/deployment" -Filter "release_notes_*.md" -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $notes) { Write-Error "No versioned release notes file found for release upload."; exit 1 }
+
+          "vip_path=$($vip.FullName)"           | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "vip_name=$($vip.Name)"               | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "notes_path=$($notes.FullName)"       | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "notes_name=$($notes.Name)"           | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+      - name: Create GitHub release
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+      - name: Upload .vip to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.release-assets.outputs.vip_path }}
+          asset_name: ${{ steps.release-assets.outputs.vip_name }}
+          asset_content_type: application/octet-stream
+      - name: Upload release notes to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.release-assets.outputs.notes_path }}
+          asset_name: ${{ steps.release-assets.outputs.notes_name }}
+          asset_content_type: text/markdown

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -238,11 +238,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Close LabVIEW 2021 before 2023 packaging
+      - name: Close LabVIEW 2021 64-bit before 2023 packaging
         uses: ./.github/actions/close-labview
         with:
           minimum_supported_lv_version: 2021
           supported_bitness: 64
+      - name: Close LabVIEW 2021 32-bit before 2023 packaging
+        uses: ./.github/actions/close-labview
+        with:
+          minimum_supported_lv_version: 2021
+          supported_bitness: 32
       - name: Generate release notes
         uses: ./.github/actions/generate-release-notes
         # output_path defaults to Tooling/deployment/release_notes.md

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -82,7 +82,7 @@ jobs:
 
   apply-deps-2023-x64:
     name: Apply VIPC (2023 x64)
-    needs: [apply-deps-2021-x86, changes]
+    needs: [close-lv-2021-before-2023, changes]
     runs-on: self-hosted-windows-lv
     steps:
       - uses: ./.github/actions/apply-vipc
@@ -95,6 +95,16 @@ jobs:
           vipc_path:                    ".github/actions/apply-vipc/runner_dependencies.vipc"
       - run: echo "No .vipc changes detected; skipping dependency application."
         if: needs.changes.outputs.vipc != 'true'
+
+  close-lv-2021-before-2023:
+    name: Close LabVIEW 2021 before 2023 tasks
+    needs: apply-deps-2021-x86
+    runs-on: self-hosted-windows-lv
+    steps:
+      - uses: ./.github/actions/close-labview
+        with:
+          minimum_supported_lv_version: 2021
+          supported_bitness: 64
 
   version:
     name: Compute Version

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -234,6 +234,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Close LabVIEW 2021 before 2023 packaging
+        uses: ./.github/actions/close-labview
+        with:
+          minimum_supported_lv_version: 2021
+          supported_bitness: 64
       - name: Generate release notes
         uses: ./.github/actions/generate-release-notes
         # output_path defaults to Tooling/deployment/release_notes.md

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -355,9 +355,6 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $provided = if (-not [string]::IsNullOrWhiteSpace($Env:INPUT_TAG)) { $Env:INPUT_TAG } else { $Env:REF_TAG }
-          if ([string]::IsNullOrWhiteSpace($provided)) {
-            Write-Error "No provided tag (ref/input) to validate against computed tag $Env:EXPECTED_TAG."
-          }
           if ($provided -ne $Env:EXPECTED_TAG) {
             Write-Error ("Provided tag '{0}' does not match computed tag '{1}'." -f $provided, $Env:EXPECTED_TAG)
           } else {

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -105,6 +105,10 @@ jobs:
         with:
           minimum_supported_lv_version: 2021
           supported_bitness: 64
+      - uses: ./.github/actions/close-labview
+        with:
+          minimum_supported_lv_version: 2021
+          supported_bitness: 32
 
   version:
     name: Compute Version
@@ -359,50 +363,3 @@ jobs:
           } else {
             Write-Host ("Tag validation ok: {0}" -f $provided)
           }
-      - name: Locate release assets
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: release-assets
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $vip = Get-ChildItem -Path "$Env:GITHUB_WORKSPACE/builds/VI Package" -Filter *.vip -File -Recurse | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-          if (-not $vip) { Write-Error "No .vip file found for release upload."; exit 1 }
-
-          $notes = Get-ChildItem -Path "$Env:GITHUB_WORKSPACE/Tooling/deployment" -Filter "release_notes_*.md" -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-          if (-not $notes) { Write-Error "No versioned release notes file found for release upload."; exit 1 }
-
-          "vip_path=$($vip.FullName)"           | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          "vip_name=$($vip.Name)"               | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          "notes_path=$($notes.FullName)"       | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          "notes_name=$($notes.Name)"           | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-      - name: Create GitHub release
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
-          draft: false
-          prerelease: false
-      - name: Upload .vip to release
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.release-assets.outputs.vip_path }}
-          asset_name: ${{ steps.release-assets.outputs.vip_name }}
-          asset_content_type: application/octet-stream
-      - name: Upload release notes to release
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.release-assets.outputs.notes_path }}
-          asset_name: ${{ steps.release-assets.outputs.notes_name }}
-          asset_content_type: text/markdown

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -88,10 +88,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           $tag = "${{ steps.form-tag.outputs.tag }}"
-          if (git rev-parse --verify --quiet $tag) {
-            Write-Host "Tag $tag already exists; skipping."
-            exit 0
-          }
           git tag $tag
           git push origin $tag
 

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,12 +1,10 @@
 name: Tag and Release
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-      - release/*
-      - hotfix/*
+  workflow_run:
+    workflows: ["CI Pipeline (Composite)"]
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -15,17 +13,24 @@ permissions:
 jobs:
   tag-and-release:
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: false
+      group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+      cancel-in-progress: true
     permissions:
       contents: write
       actions: write
     runs-on: self-hosted-windows-lv
     steps:
+      - name: Exit if upstream run not from push or failed
+        if: ${{ github.event.workflow_run.conclusion != 'success' || github.event.workflow_run.event != 'push' }}
+        run: |
+          echo "Upstream CI run conclusion=${{ github.event.workflow_run.conclusion }}, event=${{ github.event.workflow_run.event }}. Skipping tag."
+          exit 0
+
       - name: Checkout full history
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Compute version
         id: version
@@ -41,80 +46,80 @@ jobs:
           Write-Host "Tag: $tag"
           "tag=$tag" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
 
-      - name: Ensure ci-composite is green for this commit
-        id: ensure_ci
-        shell: pwsh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $repo = $Env:GITHUB_REPOSITORY
-          $workflow = "ci-composite.yml"
-          $sha = $Env:GITHUB_SHA
-          $headers = @{
-            Authorization = "Bearer $Env:GITHUB_TOKEN"
-            Accept        = "application/vnd.github+json"
-            "X-GitHub-Api-Version" = "2022-11-28"
-          }
-          $uri = "https://api.github.com/repos/$repo/actions/workflows/$workflow/runs?event=push&head_sha=$sha&status=completed&conclusion=success"
-          $response = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
-          if (-not $response.workflow_runs -or $response.workflow_runs.Count -eq 0) {
-            Write-Error "No successful ci-composite run found for commit $sha. Aborting tag creation."
-          } else {
-            $run = $response.workflow_runs[0]
-            Write-Host ("Found successful ci-composite run id {0} on branch {1}" -f $run.id, $run.head_branch)
-            if ($run.head_sha -ne $sha) {
-              Write-Error ("Latest successful ci-composite run ({0}) is for head_sha {1}, not current {2}. Aborting." -f $run.id, $run.head_sha, $sha)
-            }
-            "run_id=$($run.id)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          }
-
       - name: Fail if latest tag matches computed tag
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           $tag = "${{ steps.form-tag.outputs.tag }}"
-          $latest = git describe --tags --abbrev=0 --first-parent --match 'v*' 2>$null
+          $latest = git describe --tags --abbrev=0 2>$null
           if ($latest -and $latest -eq $tag) {
             Write-Error ("Computed tag {0} matches latest existing tag. Aborting duplicate tagging." -f $tag)
           } else {
             Write-Host ("Computed tag {0} does not match latest tag {1}. Proceeding." -f $tag, ($latest ?? "<none>"))
           }
 
-      - name: Create tag
+      - name: Create tag (with retry)
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           $tag = "${{ steps.form-tag.outputs.tag }}"
+          if (git rev-parse --verify --quiet $tag) {
+            Write-Host "Tag $tag already exists; skipping."
+            exit 0
+          }
           git tag $tag
-          git push origin $tag
+          for ($i=0; $i -lt 3; $i++) {
+            git push origin $tag && break
+            Start-Sleep -Seconds 5
+            if ($i -eq 2) {
+              Write-Error "Failed to push tag $tag after multiple attempts."
+              exit 1
+            }
+          }
 
-      - name: Download all artifacts from successful run
+      - name: Download artifacts from successful run
         uses: actions/download-artifact@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ steps.ensure_ci.outputs.run_id }}
+          run-id: ${{ github.event.workflow_run.id }}
           path: artifacts
 
       - name: Locate release assets from artifacts
         id: locate-artifacts
-        uses: ./.github/actions/locate-release-assets
-        with:
-          vip_dir: artifacts
-          notes_dir: artifacts
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = Join-Path -Path $PWD -ChildPath "artifacts"
+          $vip = Get-ChildItem -Path $root -Recurse -Filter *.vip -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $vip) { Write-Error "No .vip found in downloaded artifacts."; exit 1 }
+
+          $notes = Get-ChildItem -Path $root -Recurse -Filter "release_notes_*.md" -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $notes) { Write-Error "No release_notes_*.md found in downloaded artifacts."; exit 1 }
+
+          $expectedVersion = "$(${{ steps.version.outputs.MAJOR }}).$(${{ steps.version.outputs.MINOR }}).$(${{ steps.version.outputs.PATCH }}).$(${{ steps.version.outputs.BUILD }})"
+          if ($vip.Name -notmatch $expectedVersion) {
+            Write-Error ("Located .vip '{0}' does not contain expected version '{1}'." -f $vip.Name, $expectedVersion)
+          }
+          if ($notes.Name -notmatch $expectedVersion) {
+            Write-Error ("Located release notes '{0}' do not contain expected version '{1}'." -f $notes.Name, $expectedVersion)
+          }
+
+          "vip_path=$($vip.FullName)"     | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "vip_name=$($vip.Name)"         | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "notes_path=$($notes.FullName)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "notes_name=$($notes.Name)"     | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
 
       - name: Create GitHub release and upload assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.form-tag.outputs.tag }}
           name: ${{ steps.form-tag.outputs.tag }}
           draft: false
           prerelease: false
-          body_path: ${{ steps.locate-artifacts.outputs.notes_path }}
           files: |
             ${{ steps.locate-artifacts.outputs.vip_path }}
             ${{ steps.locate-artifacts.outputs.notes_path }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -16,7 +16,7 @@ jobs:
   tag-and-release:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     permissions:
       contents: write
       actions: write
@@ -74,7 +74,7 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $tag = "${{ steps.form-tag.outputs.tag }}"
-          $latest = git describe --tags --abbrev=0 2>$null
+          $latest = git describe --tags --abbrev=0 --first-parent --match 'v*' 2>$null
           if ($latest -and $latest -eq $tag) {
             Write-Error ("Computed tag {0} matches latest existing tag. Aborting duplicate tagging." -f $tag)
           } else {
@@ -91,7 +91,7 @@ jobs:
           git tag $tag
           git push origin $tag
 
-      - name: Download artifacts from successful run
+      - name: Download all artifacts from successful run
         uses: actions/download-artifact@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   tag-and-release:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.sha }}
+      cancel-in-progress: true
     permissions:
       contents: write
       actions: write

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   tag-and-release:
     concurrency:
-      group: ${{ github.workflow }}-${{ github.sha }}
+      group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     permissions:
       contents: write
@@ -104,48 +104,21 @@ jobs:
 
       - name: Locate release assets from artifacts
         id: locate-artifacts
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $root = Join-Path -Path $PWD -ChildPath "artifacts"
-          $vip = Get-ChildItem -Path $root -Recurse -Filter *.vip -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-          if (-not $vip) { Write-Error "No .vip found in downloaded artifacts."; exit 1 }
+        uses: ./.github/actions/locate-release-assets
+        with:
+          vip_dir: artifacts
+          notes_dir: artifacts
 
-          $notes = Get-ChildItem -Path $root -Recurse -Filter "release_notes_*.md" -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-          if (-not $notes) { Write-Error "No release_notes_*.md found in downloaded artifacts."; exit 1 }
-
-          "vip_path=$($vip.FullName)"     | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          "vip_name=$($vip.Name)"         | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          "notes_path=$($notes.FullName)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          "notes_name=$($notes.Name)"     | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-
-      - name: Create GitHub release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub release and upload assets
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.form-tag.outputs.tag }}
-          release_name: ${{ steps.form-tag.outputs.tag }}
+          name: ${{ steps.form-tag.outputs.tag }}
           draft: false
           prerelease: false
-
-      - name: Upload .vip to release
-        uses: actions/upload-release-asset@v1
+          body_path: ${{ steps.locate-artifacts.outputs.notes_path }}
+          files: |
+            ${{ steps.locate-artifacts.outputs.vip_path }}
+            ${{ steps.locate-artifacts.outputs.notes_path }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.locate-artifacts.outputs.vip_path }}
-          asset_name: ${{ steps.locate-artifacts.outputs.vip_name }}
-          asset_content_type: application/octet-stream
-
-      - name: Upload release notes to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.locate-artifacts.outputs.notes_path }}
-          asset_name: ${{ steps.locate-artifacts.outputs.notes_name }}
-          asset_content_type: text/markdown

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,148 @@
+name: Tag and Release
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - release/*
+      - hotfix/*
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  tag-and-release:
+    permissions:
+      contents: write
+      actions: write
+    runs-on: self-hosted-windows-lv
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        uses: ./.github/actions/compute-version
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Form tag
+        id: form-tag
+        shell: pwsh
+        run: |
+          $tag = "v${{ steps.version.outputs.MAJOR }}.${{ steps.version.outputs.MINOR }}.${{ steps.version.outputs.PATCH }}.${{ steps.version.outputs.BUILD }}"
+          Write-Host "Tag: $tag"
+          "tag=$tag" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+
+      - name: Ensure ci-composite is green for this commit
+        id: ensure_ci
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repo = $Env:GITHUB_REPOSITORY
+          $workflow = "ci-composite.yml"
+          $sha = $Env:GITHUB_SHA
+          $headers = @{
+            Authorization = "Bearer $Env:GITHUB_TOKEN"
+            Accept        = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          $uri = "https://api.github.com/repos/$repo/actions/workflows/$workflow/runs?event=push&head_sha=$sha&status=completed&conclusion=success"
+          $response = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+          if (-not $response.workflow_runs -or $response.workflow_runs.Count -eq 0) {
+            Write-Error "No successful ci-composite run found for commit $sha. Aborting tag creation."
+          } else {
+            $run = $response.workflow_runs[0]
+            Write-Host ("Found successful ci-composite run id {0} on branch {1}" -f $run.id, $run.head_branch)
+            if ($run.head_sha -ne $sha) {
+              Write-Error ("Latest successful ci-composite run ({0}) is for head_sha {1}, not current {2}. Aborting." -f $run.id, $run.head_sha, $sha)
+            }
+            "run_id=$($run.id)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          }
+
+      - name: Fail if latest tag matches computed tag
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $tag = "${{ steps.form-tag.outputs.tag }}"
+          $latest = git describe --tags --abbrev=0 2>$null
+          if ($latest -and $latest -eq $tag) {
+            Write-Error ("Computed tag {0} matches latest existing tag. Aborting duplicate tagging." -f $tag)
+          } else {
+            Write-Host ("Computed tag {0} does not match latest tag {1}. Proceeding." -f $tag, ($latest ?? "<none>"))
+          }
+
+      - name: Create tag
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          $tag = "${{ steps.form-tag.outputs.tag }}"
+          if (git rev-parse --verify --quiet $tag) {
+            Write-Host "Tag $tag already exists; skipping."
+            exit 0
+          }
+          git tag $tag
+          git push origin $tag
+
+      - name: Download artifacts from successful run
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.ensure_ci.outputs.run_id }}
+          path: artifacts
+
+      - name: Locate release assets from artifacts
+        id: locate-artifacts
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = Join-Path -Path $PWD -ChildPath "artifacts"
+          $vip = Get-ChildItem -Path $root -Recurse -Filter *.vip -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $vip) { Write-Error "No .vip found in downloaded artifacts."; exit 1 }
+
+          $notes = Get-ChildItem -Path $root -Recurse -Filter "release_notes_*.md" -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $notes) { Write-Error "No release_notes_*.md found in downloaded artifacts."; exit 1 }
+
+          "vip_path=$($vip.FullName)"     | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "vip_name=$($vip.Name)"         | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "notes_path=$($notes.FullName)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "notes_name=$($notes.Name)"     | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.form-tag.outputs.tag }}
+          release_name: ${{ steps.form-tag.outputs.tag }}
+          draft: false
+          prerelease: false
+
+      - name: Upload .vip to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.locate-artifacts.outputs.vip_path }}
+          asset_name: ${{ steps.locate-artifacts.outputs.vip_name }}
+          asset_content_type: application/octet-stream
+
+      - name: Upload release notes to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.locate-artifacts.outputs.notes_path }}
+          asset_name: ${{ steps.locate-artifacts.outputs.notes_name }}
+          asset_content_type: text/markdown


### PR DESCRIPTION
This PR introduces an automated tag-and-release workflow that gates on successful CI runs, enforces per-commit concurrency for deterministic builds, and improves LabVIEW version separation by ensuring LabVIEW 2021 is closed before LabVIEW 2023 tasks begin.


- Enforced deterministic per-commit concurrency for ci-composite and tag-and-release workflows.
- Added automated tagging/release workflow gated on a green ci-composite run, reusing artifacts and validating tags.
- Hardened LabVIEW version separation: force-close LV2021 before 2023 preflight/packaging, and inserted a dedicated 2021-close job before 2023 tasks.
- Improved artifact handling: versioned release notes artifact, raw .vip artifact naming, inline log/release-notes dumping, and build log surfacing on failure.