### PR TITLE
Rename jobs that build Lvlibp

### DIFF
--- a/.github/workflows/build-lvlibp-linux-container.yml
+++ b/.github/workflows/build-lvlibp-linux-container.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-lvlibp:
-    name: Build LabVIEW Packed Library (Linux)
+    name: Build lv_icon PPL Linux 64-bit
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-lvlibp-linux-container.yml
+++ b/.github/workflows/build-lvlibp-linux-container.yml
@@ -62,7 +62,7 @@ jobs:
           
           Please either:
           1. Use LabVIEW 2025q3 or later (e.g., 2025q3, 2026q1)
-          2. Use GitHub-hosted runners instead of Docker (see build-lvlibp-win32.yml)
+          2. Use GitHub-hosted runners instead of Docker
           
           Available Docker images: https://hub.docker.com/r/nationalinstruments/labview
           "@

--- a/.github/workflows/build-lvlibp-linux-container.yml
+++ b/.github/workflows/build-lvlibp-linux-container.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-lvlibp:
-    name: Build lv_icon PPL Linux 64-bit
+    name: Build LabVIEW Packed Library (Linux)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-lvlibp-windows-container.yml
+++ b/.github/workflows/build-lvlibp-windows-container.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-lvlibp:
-    name: Build lv_icon PPL Windows 64-bit
+    name: Build LabVIEW Packed Library (Windows)
     runs-on: windows-2022
 
     steps:

--- a/.github/workflows/build-lvlibp-windows-container.yml
+++ b/.github/workflows/build-lvlibp-windows-container.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-lvlibp:
-    name: Build LabVIEW Packed Library (Windows)
+    name: Build lv_icon PPL Windows 64-bit
     runs-on: windows-2022
 
     steps:

--- a/.github/workflows/build-lvlibp-windows-github-hosted.yml
+++ b/.github/workflows/build-lvlibp-windows-github-hosted.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   build-lvlibp-win:
-    name: Build LabVIEW Packed Library (Windows)
+    name: Build lv_icon PPL Windows 32-bit
     runs-on: windows-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/build-lvlibp-windows-github-hosted.yml
+++ b/.github/workflows/build-lvlibp-windows-github-hosted.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   build-lvlibp-win:
-    name: Build lv_icon PPL Windows 32-bit
+    name: Build LabVIEW Packed Library (Windows)
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -102,15 +102,22 @@ jobs:
             $availableArch = ($platformData.PSObject.Properties.Name -join ', ')
             throw "No $arch ISO URL found for version $lvVersion on $platform. Available architectures: $availableArch"
           }
-          
+
+          $packageId = $platformData.package_id
+          if ([string]::IsNullOrWhiteSpace($packageId)) {
+            throw "No package_id found for version $lvVersion on $platform in .lv-iso-map.json"
+          }
+
           Write-Host "Resolved ISO URL ($platform/$arch): $isoUrl"
+          Write-Host "Package ID: $packageId"
           Write-Host "Build bitness: $bitness"
-          
-          echo "LV_VERSION=$lvVersion" >> $env:GITHUB_ENV
-          echo "LV_YEAR=$lvYear" >> $env:GITHUB_ENV
-          echo "ISO_URL=$isoUrl" >> $env:GITHUB_ENV
-          echo "BITNESS=$bitness" >> $env:GITHUB_ENV
-          echo "ARCH=$arch" >> $env:GITHUB_ENV
+
+          "LV_VERSION=$lvVersion" >> $env:GITHUB_ENV
+          "LV_YEAR=$lvYear" >> $env:GITHUB_ENV
+          "ISO_URL=$isoUrl" >> $env:GITHUB_ENV
+          "PACKAGE_ID=$packageId" >> $env:GITHUB_ENV
+          "BITNESS=$bitness" >> $env:GITHUB_ENV
+          "ARCH=$arch" >> $env:GITHUB_ENV
 
           if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
             @(
@@ -118,6 +125,7 @@ jobs:
               '',
               ('- LabVIEW version: `{0}`' -f $lvVersion),
               ('- LabVIEW year: `{0}`' -f $lvYear),
+              ('- Package ID: `{0}`' -f $packageId),
               '- Platform: `windows`',
               ('- Bitness: `{0}` (`{1}`)' -f $bitness, $arch),
               ('- ISO URL: `{0}`' -f $isoUrl)
@@ -135,7 +143,7 @@ jobs:
           labview_iso_url: ${{ env.ISO_URL }}
           timeout_seconds: 1800
           serial_number: ${{ secrets.LABVIEW_SERIAL_NUMBER }}
-          package_id: 'LabVIEW_COM_PKG 25.0300'
+          package_id: ${{ env.PACKAGE_ID }}
           log_level: 'DEBUG'
 
       - name: Configure LabVIEW

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           "manifest_path=$manifestPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Upload run manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: run-manifest
           path: ${{ steps.meta.outputs.manifest_path }}
@@ -81,7 +81,7 @@ jobs:
       minor: ${{ steps.lv.outputs.minor }}
       numeric: ${{ steps.lv.outputs.numeric }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -100,7 +100,7 @@ jobs:
     needs: [run-metadata, version-gate]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload pylavi artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pylavi-linux
           path: |
@@ -129,7 +129,7 @@ jobs:
     needs: [run-metadata]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload VI Analyzer logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vi-analyzer-linux-logs
           path: ${{ steps.vi.outputs.logs_root }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload VI Analyzer reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vi-analyzer-reports
           path: ${{ steps.vi.outputs.reports_root }}
@@ -163,33 +163,33 @@ jobs:
 
       - name: Upload VI Analyzer status
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vi-analyzer-status
           path: ${{ steps.vi.outputs.status_path }}
           if-no-files-found: error
   
   build-lvlibp-linux-container:
-    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.raw }} x64 (Linux Container)
+    name: Build lv_icon PPL using 2026q1 LabVIEW x64 (Linux Container)
     needs: [run-metadata, version-gate]
     uses: ./.github/workflows/build-lvlibp-linux-container.yml
     with:
       labview_version: '2026q1'
 
   build-lvlibp-windows-container:
-    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.raw }} x64 (Windows Container)
+    name: Build lv_icon PPL using 2026q1 LabVIEW x64 (Windows Container)
     needs: [run-metadata, version-gate]
     uses: ./.github/workflows/build-lvlibp-windows-container.yml
     with:
       labview_version: '2026q1'
 
   build-lvlibp-windows-github-hosted:
-    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.raw }} x32 (Windows GitHub-Hosted)
+    name: Build lv_icon PPL using 2026q1 LabVIEW x32 (Windows GitHub-Hosted)
     if: github.event_name != 'pull_request'
     needs: [run-metadata, version-gate]
     uses: ./.github/workflows/build-lvlibp-windows-github-hosted.yml
     with:
-      labview_version: ''
+      labview_version: '2026q1'
       bitness: '32'
     secrets:
       LABVIEW_SERIAL_NUMBER: ${{ secrets.LABVIEW_SERIAL_NUMBER }}
@@ -208,7 +208,7 @@ jobs:
       BUILD_PPL_WINDOWS_CONTAINER_RESULT: ${{ needs.build-lvlibp-windows-container.result }}
       BUILD_PPL_WINDOWS_GITHUB_HOSTED_RESULT: ${{ needs.build-lvlibp-windows-github-hosted.result }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,21 +170,21 @@ jobs:
           if-no-files-found: error
   
   build-lvlibp-linux-container:
-    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.year }}.${{ needs.version-gate.outputs.minor }} x64 (Linux Container)
+    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.raw }} x64 (Linux Container)
     needs: [run-metadata, version-gate]
     uses: ./.github/workflows/build-lvlibp-linux-container.yml
     with:
       labview_version: '2026q1'
 
   build-lvlibp-windows-container:
-    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.year }}.${{ needs.version-gate.outputs.minor }} x64 (Windows Container)
+    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.raw }} x64 (Windows Container)
     needs: [run-metadata, version-gate]
     uses: ./.github/workflows/build-lvlibp-windows-container.yml
     with:
       labview_version: '2026q1'
 
   build-lvlibp-windows-github-hosted:
-    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.year }}.${{ needs.version-gate.outputs.minor }} x32 (Windows GitHub-Hosted)
+    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.raw }} x32 (Windows GitHub-Hosted)
     if: github.event_name != 'pull_request'
     needs: [run-metadata, version-gate]
     uses: ./.github/workflows/build-lvlibp-windows-github-hosted.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,21 +170,21 @@ jobs:
           if-no-files-found: error
   
   build-lvlibp-linux-container:
-    name: Build LVLIBP (Linux Container)
+    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.year }}.${{ needs.version-gate.outputs.minor }} x64 (Linux Container)
     needs: [run-metadata, version-gate]
     uses: ./.github/workflows/build-lvlibp-linux-container.yml
     with:
       labview_version: '2026q1'
 
   build-lvlibp-windows-container:
-    name: Build LVLIBP (Windows Container)
+    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.year }}.${{ needs.version-gate.outputs.minor }} x64 (Windows Container)
     needs: [run-metadata, version-gate]
     uses: ./.github/workflows/build-lvlibp-windows-container.yml
     with:
       labview_version: '2026q1'
 
   build-lvlibp-windows-github-hosted:
-    name: Build LVLIBP (Windows GitHub-Hosted)
+    name: Build lv_icon PPL for LabVIEW ${{ needs.version-gate.outputs.year }}.${{ needs.version-gate.outputs.minor }} x32 (Windows GitHub-Hosted)
     if: github.event_name != 'pull_request'
     needs: [run-metadata, version-gate]
     uses: ./.github/workflows/build-lvlibp-windows-github-hosted.yml

--- a/.lv-iso-map.json
+++ b/.lv-iso-map.json
@@ -3,12 +3,14 @@
   "versions": {
     "2025q3": {
       "windows": {
-        "x86": "https://download.ni.com/support/softlib/labview/labview_development_system/2025_Q3/ni-labview-2025-community-x86_25.3.3_offline.iso"
+        "x86": "https://download.ni.com/support/softlib/labview/labview_development_system/2025_Q3/ni-labview-2025-community-x86_25.3.3_offline.iso",
+        "package_id": "LabVIEW_COM_PKG 25.0300"
       }
     },
     "2026q1": {
       "windows": {
-        "x86": "https://download.ni.com/support/softlib/labview/labview_development_system/2026_Q1/ni-labview-2026-community-x86_26.1.0_offline.iso"
+        "x86": "https://download.ni.com/support/softlib/labview/labview_development_system/2026_Q1/ni-labview-2026-community-x86_26.1.0_offline.iso",
+        "package_id": "LabVIEW_COM_PKG 26.0100"
       }
     }
   }

--- a/Tooling/tests/CiPipelineCompositeContract.Tests.ps1
+++ b/Tooling/tests/CiPipelineCompositeContract.Tests.ps1
@@ -50,8 +50,8 @@ Describe 'CI pipeline composite contract' {
             ($isOfficial -or $isAllowedLocal) | Should -BeTrue -Because "Unexpected uses target in CI pipeline: $useValue"
         }
 
-        $usesValues | Should -Contain 'actions/checkout@v4'
-        $usesValues | Should -Contain 'actions/upload-artifact@v4'
+        $usesValues | Should -Contain 'actions/checkout@v5'
+        $usesValues | Should -Contain 'actions/upload-artifact@v6'
         $usesValues | Should -Contain './.github/actions/pylavi-ci'
         $usesValues | Should -Contain './.github/actions/vi-analyzer-ci'
         $usesValues | Should -Contain './.github/workflows/build-lvlibp-linux-container.yml'


### PR DESCRIPTION
# Summary of Changes

1. This PR renames the jobs that build a PPL (.lvlibp) by making the names more meaningful. Now the job names have the version which `ci.yml` reads from `.lvversion` file so that it is clear for which LabVIEW version the PPL is being built for.
The job names in the individual workflows have also been changed to something more detailed.

2. The actions in the main CI pipeline have also been updated to use Node 24. The Pipeline contract has also been updated to verify the same.

3. The Package ID is also read from the json file along with the ISO url.

# Testing

The job names are updated dynamically according to the version in `.lvversion` file as seen in this run: https://github.com/KSharma-NI/labview-icon-editor/actions/runs/23886393866

<img width="288" height="512" alt="image" src="https://github.com/user-attachments/assets/d0ba6cd3-bd79-43ab-ae49-8f1c049e0498" />


