### PR TITLE
Update Lvlibp build action to use the general build spec action

### DIFF
--- a/.github/workflows/build-lvlibp-linux-container.yml
+++ b/.github/workflows/build-lvlibp-linux-container.yml
@@ -137,7 +137,7 @@ jobs:
           }
       
       - name: Build PPL with Docker
-        uses: ni/open-source/build-lvlibp-docker-linux@actions
+        uses: ni/open-source/build-spec-docker-linux@actions
         with:
           minimum_supported_lv_version: '2026'
           supported_bitness: '64'

--- a/.github/workflows/build-lvlibp-windows-container.yml
+++ b/.github/workflows/build-lvlibp-windows-container.yml
@@ -137,7 +137,7 @@ jobs:
           }
 
       - name: Build PPL with Windows Docker
-        uses: ni/open-source/build-lvlibp-docker-windows@actions
+        uses: ni/open-source/build-spec-docker-windows@actions
         with:
           minimum_supported_lv_version: '2026'
           supported_bitness: '64'

--- a/.github/workflows/build-lvlibp-windows-github-hosted.yml
+++ b/.github/workflows/build-lvlibp-windows-github-hosted.yml
@@ -206,7 +206,7 @@ jobs:
           }
 
       - name: Build PPL
-        uses: ni/open-source/build-lvlibp-github-hosted-windows@actions
+        uses: ni/open-source/build-spec-github-hosted-windows@actions
         with:
           minimum_supported_lv_version: ${{ env.LV_YEAR }}
           supported_bitness: ${{ env.BITNESS }}


### PR DESCRIPTION
# Summary of Changes

Recently, an action to build any build spec in a project was created in [ni/open-source](https://github.com/ni/open-source/pull/38). As part of this change the action to build lvlibp in particular were refactored and made to support any build spec. So, this PR uses the refactored actions to build the PPL (lvlibp) files. 


## Testing

The CI checks in the PR will use the renamed actions. The actions seem to complete successfully.
